### PR TITLE
Fix Node-RED crash when sending command

### DIFF
--- a/MoonNode.js
+++ b/MoonNode.js
@@ -631,7 +631,6 @@ module.exports = function(RED) {
             });
             
             node.moonNodeWS.on('open', function open() {
-                node.MoonID = getMoonID();
                 //Send the Command
                 var tmpPayload = {
                     "jsonrpc": "2.0",
@@ -639,7 +638,7 @@ module.exports = function(RED) {
                     "params": {
                         "script": strCMD
                     },
-                    "id": MoonID
+                    "id": getMoonID(),
                 }
                 node.moonNodeWS.send(JSON.stringify(tmpPayload));
                 if(node.stateless){


### PR DESCRIPTION
Unreferenced `MoonID` causes Node-RED to crash when sending a command to Moonraker.

```
4 Feb 10:51:14 - [red] Uncaught Exception:
4 Feb 10:51:14 - [error] ReferenceError: MoonID is not defined
    at WebSocket.open (/data/node_modules/node-red-contrib-moonnode/MoonNode.js:642:27)
    at WebSocket.emit (events.js:400:28)
    at WebSocket.emit (domain.js:475:12)
    at WebSocket.setSocket (/data/node_modules/node-red-contrib-moonnode/node_modules/ws/lib/websocket.js:225:10)
    at ClientRequest.<anonymous> (/data/node_modules/node-red-contrib-moonnode/node_modules/ws/lib/websocket.js:810:1
5)
    at ClientRequest.emit (events.js:400:28)
    at ClientRequest.emit (domain.js:475:12)
    at Socket.socketOnData (_http_client.js:553:11)
    at Socket.emit (events.js:400:28)
    at Socket.emit (domain.js:475:12)
```